### PR TITLE
Correctly check if phraseapp is enabled in injectIntl translate.

### DIFF
--- a/src/injectIntl.js
+++ b/src/injectIntl.js
@@ -1,6 +1,6 @@
 import { Component, createElement } from 'react';
 import { injectIntl as injectIntlReact } from 'react-intl'
-import { escapeId } from './functions'
+import { escapeId, isPhraseEnabled } from './functions'
 
 export function injectIntl(WrappedComponent, options = {}) {
     class InjectPhrase extends Component {
@@ -13,7 +13,7 @@ export function injectIntl(WrappedComponent, options = {}) {
         }
 
         translate(keyName) {
-            if (!window.PHRASEAPP_DISABLED) {
+            if (isPhraseEnabled()) {
                 let escapedString = keyName.replace("<", "[[[[[[html_open]]]]]]").replace(">", "[[[[[[html_close]]]]]]");
                 return escapeId(escapedString);
             } else {


### PR DESCRIPTION
If we are using the `phraseEnabled` config option (which is injected into `window.PHRASEAPP_ENABLED` env var), injectIntl doesn't take it into account because it is currently looking for a `window.PHRASEAPP_DISABLED` env var.

This PR fixes that by using the isPhraseEnabled() utility function, so you don't have to specify that phraseapp is enabled/disabled in 2 differents ways.