### PR TITLE
phraseapp.com -> app.phrase.com

### DIFF
--- a/__tests__/functions.ts
+++ b/__tests__/functions.ts
@@ -9,5 +9,5 @@ test('translation should be rendered by default', () => {
     functions.initializePhraseAppEditor(config)
 
     expect(document.getElementsByTagName('script')[0].src)
-        .toMatch(/https:\/\/phraseapp.com\/assets\/in-context-editor\/2.0\/app.js\?[\d]/);
+        .toMatch(/https:\/\/app.phrase.com\/assets\/in-context-editor\/2.0\/app.js\?[\d]/);
 });

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -18,7 +18,7 @@ export function initializePhraseAppEditor (config: any) {
       const phraseapp = document.createElement('script');
       phraseapp.type = 'text/javascript';
       phraseapp.async = true;
-      phraseapp.src = ['https://', 'phraseapp.com/assets/in-context-editor/2.0/app.js?', new Date().getTime()].join('');
+      phraseapp.src = ['https://', 'app.phrase.com/assets/in-context-editor/2.0/app.js?', new Date().getTime()].join('');
       var s = document.getElementsByTagName('script')[0];
       if (s != undefined) {
         s.parentNode.insertBefore(phraseapp, s);


### PR DESCRIPTION
The app.js script now redirects to app.phrase.com rather than phraseapp.com, so let's just link directly there and save the redirect