### PR TITLE
Limit react-intl support to < 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "react": ">= 15.5.4",
-    "react-intl": ">= 2.2.3"
+    "react-intl": ">= 2.2.3 < 3"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
react-intl >= 3 currently does not work with this library. Limit the supported version range for now to create a release supporting at least react 16. Support for newer versions of react-intl will be added in a followup release