### PR TITLE
docs: unify style of README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # react-intl-phraseapp
 
-[![Build Status](https://travis-ci.org/phrase/angular-phrase.png)](https://travis-ci.org/phrase/angular-phrase)
+[![Build Status](https://travis-ci.org/phrase/react-intl-phraseapp.png)](https://travis-ci.org/phrase/react-intl-phraseapp)
 
-react-intl-phraseapp is an addon for [react-intl](https://github.com/yahoo/react-intl) that lets you connect localized react applications to the PhraseApp In-Context Editor.
+react-intl-phraseapp is an addon for [react-intl](https://github.com/yahoo/react-intl) that lets you connect localized react applications to the Phrase In-Context Editor.
 
 ## Prerequisites
 
 To use react-intl-phraseapp with your application you have to:
 
-* Sign up for a PhraseApp account: [https://phraseapp.com/en/signup](https://phraseapp.com/en/signup)
+* Sign up for a Phrase account: [https://app.phrase.com/signup](https://app.phrase.com/signup)
 * Use the excellent [react-intl](https://github.com/yahoo/react-intl) module by yahoo for localization in your react app
 
 ## Demo
@@ -17,20 +17,25 @@ You can find a demo project on [GitHub](https://github.com/phrase/react-intl-phr
 
 ## Installation
 
-### via NPM:
+### via NPM
 
-    npm install react-intl-phraseapp
+```bash
+npm install react-intl-phraseapp
+```
 
 ### Build from source
 
 You can also build it directly from source to get the latest and greatest:
 
-    npm run dist
+```bash
+npm run dist
+```
 
 ### Development
 
-	npm install
-
+```bash
+npm install
+```
 
 ### Configure
 
@@ -64,7 +69,7 @@ let config = {
 initializePhraseAppEditor(config);
 ```
 
-If this does not work for you, you can also integrate the [JavaScript snippet manually](https://help.phraseapp.com/phraseapp-for-developers/how-to-setup-and-configure-the-phraseapp-in-context-editor-ice/integrate-in-context-editor-into-any-web-framework).
+If this does not work for you, you can also integrate the [JavaScript snippet manually](https://help.phrase.com/en/articles/2183908-integrate-in-context-editor-into-any-web-framework).
 
 ### Import from react-intl-phrasapp rather than from react-intl
 
@@ -76,19 +81,20 @@ Find all imports of `FormattedMessage`, `FormattedHTMLMessage` and change the so
 
 This library might not work out of the box for some older browser or IE11. We recommend to add [Babel](https://github.com/babel/babel) to the build pipeline if those browser need to be supported.
 
-## How does it work?
+## How does it work
 
-The library inherits common components of the react-intl packages. In case you enabled PhraseApp by calling `initializePhraseAppEditor` the behaviour of the components will be changed.
+The library inherits common components of the react-intl packages. In case you enabled Phrase by calling `initializePhraseAppEditor` the behaviour of the components will be changed.
 
 ## Support
 
-**Question?** Contact us at: [phraseapp.com/contact](https://phraseapp.com/contact)
+**Question?** Contact us at: [phrase.com/contact](https://phrase.com/contact)
 
 **Issue?** use GitHub issues and share the problem
 
 ## Test
 
 Run unit tests using jest:
-```
+
+```bash
 npm test
 ```


### PR DESCRIPTION
fix travis-ci badge link
change all link, so they point to new phrase.com domain