### PR TITLE
Add back binding for functions within injectIntl

### DIFF
--- a/__tests__/FormattedHTMLMessage.tsx
+++ b/__tests__/FormattedHTMLMessage.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import * as Utils from '../helper/test_utils'
+import * as React from 'react';
+import * as Utils from '../helper/test_utils';
 
 import {FormattedHTMLMessage} from '../src/FormattedHTMLMessage';
 

--- a/__tests__/__snapshots__/injectIntl.tsx.snap
+++ b/__tests__/__snapshots__/injectIntl.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`injectIntl formatMessage when phrase is enabled key should be rendered using translate and injectIntl HOC 1`] = `
+<div>
+  {{__phrase_key.id__}}
+</div>
+`;
+
+exports[`injectIntl formatMessage when phrase is not enabled key should be rendered using translate and injectIntl HOC 1`] = `
+<div>
+  Some translation
+</div>
+`;
+
+exports[`injectIntl translate when phrase is enabled key should be rendered using translate and injectIntl HOC 1`] = `
+<div>
+  {{__phrase_key.id__}}
+</div>
+`;
+
+exports[`injectIntl translate when phrase is not enabled key should be rendered using translate and injectIntl HOC 1`] = `
+<div>
+  Some translation
+</div>
+`;

--- a/__tests__/injectIntl.tsx
+++ b/__tests__/injectIntl.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import * as Utils from '../helper/test_utils';
+
+import { injectIntl } from '../src';
+
+const key = 'key.id';
+const locale = 'en';
+const messages = {
+  [key]: 'Some translation'
+};
+
+describe('injectIntl', () => {
+  describe('translate', () => {
+    let ComponentUnderTest;
+
+    beforeEach(() => {
+      function Component({ translate }) {
+        const translation = translate(key);
+
+        return (<div>{translation}</div>);
+      }
+
+      ComponentUnderTest = injectIntl(Component);
+    });
+
+    describe('when phrase is enabled', () => {
+      test('key should be rendered using translate and injectIntl HOC', () => {
+        Utils.setPhraseConfig();
+
+        const component = Utils.createComponentWithIntl(<ComponentUnderTest />, {locale, messages});
+
+        const tree = component.toJSON();
+
+        expect(tree).toMatchSnapshot();
+      });
+    });
+
+    describe('when phrase is not enabled', () => {
+      test('key should be rendered using translate and injectIntl HOC', () => {
+        Utils.setPhraseConfig();
+        Utils.disablePhrase();
+
+        const component = Utils.createComponentWithIntl(<ComponentUnderTest />, {locale, messages});
+
+        const tree = component.toJSON();
+
+        expect(tree).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('formatMessage', () => {
+    let ComponentUnderTest;
+
+    beforeEach(() => {
+      function Component({ formatMessage }) {
+        const message = formatMessage({ id: key });
+
+        return (<div>{message}</div>);
+      }
+
+      ComponentUnderTest = injectIntl(Component);
+    });
+
+    describe('when phrase is enabled', () => {
+      test('key should be rendered using translate and injectIntl HOC', () => {
+        Utils.setPhraseConfig();
+
+        const component = Utils.createComponentWithIntl(<ComponentUnderTest />, {locale, messages});
+
+        const tree = component.toJSON();
+
+        expect(tree).toMatchSnapshot();
+      });
+    });
+
+    describe('when phrase is not enabled', () => {
+      test('key should be rendered using translate and injectIntl HOC', () => {
+        Utils.setPhraseConfig();
+        Utils.disablePhrase();
+
+        const component = Utils.createComponentWithIntl(<ComponentUnderTest />, {locale, messages});
+
+        const tree = component.toJSON();
+
+        expect(tree).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/helper/test_utils.tsx
+++ b/helper/test_utils.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {IntlProvider} from 'react-intl';
 
-const renderer = require('react-test-renderer')
+const renderer = require('react-test-renderer');
 
 export function setPhraseConfig() {
     Object.defineProperty(window, "PHRASEAPP_CONFIG", {
@@ -17,7 +17,14 @@ export function setPhraseConfig() {
     });
 }
 
-export const createComponentWithIntl = (children : any, props = { locale: 'en' }) => {
+export function disablePhrase() {
+    Object.defineProperty(window, "PHRASEAPP_ENABLED", {
+        writable: true,
+        value: false
+    });
+}
+
+export const createComponentWithIntl = (children : any, props: {locale: string, messages?: Record<string, string>} = { locale: 'en' }) => {
     return renderer.create(
         <IntlProvider textComponent="span" {...props}>
             {children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-phraseapp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/injectIntl.tsx
+++ b/src/injectIntl.tsx
@@ -9,16 +9,24 @@ export type ReactIntlPhraseProps = {
 
 export function injectIntl(WrappedComponent: React.ComponentType<ReactIntlPhraseProps>, options?: Parameters<typeof injectIntlReact>[1]): ReturnType<typeof injectIntlReact> & React.FC<ReactIntlPhraseProps> {
     class InjectPhrase extends React.Component implements ReactIntlPhraseProps {
+        constructor(...args: ConstructorParameters<typeof React.Component>) {
+            super(...args);
+
+            this.render = this.render.bind(this);
+            this.translate = this.translate.bind(this);
+            this.formatMessage = this.formatMessage.bind(this);
+        }
+
         translate(keyName: string): ReturnType<ReactIntlPhraseProps['translate']> {
             if (isPhraseEnabled()) {
                 const escapedString = keyName.replace("<", "[[[[[[html_open]]]]]]").replace(">", "[[[[[[html_close]]]]]]");
                 return escapeId(escapedString);
             } else {
-                return this.props['intl'].formatMessage({ "id": keyName })
+                return this.props['intl'].formatMessage({ "id": keyName });
             }
         }
 
-        formatMessage(messageDescriptor: {id?: string}): ReturnType<ReactIntlPhraseProps['formatMessage']> {
+        formatMessage(messageDescriptor: { id?: string }): ReturnType<ReactIntlPhraseProps['formatMessage']> {
             const { id } = messageDescriptor;
             if (!id) {
                 console.error("formatMessage requires an id")


### PR DESCRIPTION
## Description

This PR addresses the issue that we recently faced after upgrading this package to the 2.0.0 version.

The issue was caused by removed bindings from the `injectIntl` HOC for the `translate` function. After this removal, for instance, when using the `translate` function within a component, the function fails with the error:

```ts
TypeError: Cannot read property 'props' of undefined

at translate (react-intl-phraseapp/src/injectIntl.tsx:25:29)
at Component (react-intl-phraseapp/__tests__/injectIntl.tsx:7:23)
```

That points to [the line](https://github.com/phrase/react-intl-phraseapp/blob/master/src/injectIntl.tsx#L17) where the line where `props` are accessed from `this` object:

```ts
return this.props['intl'].formatMessage({ "id": keyName })
```

This PR binds again the `translate`, `formatMessage` and `render` that are within the HOC. It also covers the `translate` function with a test that covers the regression.