### PR TITLE
configure webpack externals to support root/global scope

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,10 +10,20 @@ module.exports = {
             },
         ]
     },
-    externals: [
-        "react-intl",
-        "react"
-    ],
+    externals: {
+        "react-intl": {
+            root: 'ReactIntl',
+            commonjs2: 'react-intl',
+            commonjs: 'react-intl',
+            amd: 'react-intl'
+        },
+        "react": {
+            root: 'React',
+            commonjs2: 'react',
+            commonjs: 'react',
+            amd: 'react'
+        }
+    },
     entry: [
         './src/index.ts'
     ],


### PR DESCRIPTION
We were trying to use your library with Single-SPA, using import-maps, but the [UMD build](https://unpkg.com/browse/react-intl-phraseapp@3.0.0/dist/react-intl-phraseapp.js) was lacking the correct global scope names for the external dependencies (React & ReactIntl).

This PR follows the advice from https://webpack.js.org/guides/author-libraries/#externalize-lodash  and doing so would enable usage with import-map in browser directly.

Comparing the `dist` output, I do not expect any side effects with existing usage. 