### PR TITLE
fix: Define exports for sub files of react-intl-phraseapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,19 @@
   ],
   "main": "dist/index.js",
   "exports": {
+    ".": "./dist/index.js",
     "./functions": "./dist/functions.js",
     "./injectIntl": "./dist/injectIntl.js",
     "./useIntl": "./dist/useIntl.js",
     "./useSSRIntl": "./dist/useSSRIntl.js"
+  },
+  "typesVersions": {
+    "*": {
+      "functions": ["dist/functions.d.ts"],
+      "injectIntl": ["dist/injectIntl.d.ts"],
+      "useIntl": ["dist/useIntl.d.ts"],
+      "useSSRIntl": ["dist/useSSRIntl.d.ts"]
+    }
   },
   "sideEffects": false,
   "jest": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
     "dist/"
   ],
   "main": "dist/index.js",
+  "exports": {
+    "./functions": "./dist/functions.js",
+    "./injectIntl": "./dist/injectIntl.js",
+    "./useIntl": "./dist/useIntl.js",
+    "./useSSRIntl": "./dist/useSSRIntl.js"
+  },
   "sideEffects": false,
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-phraseapp",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The In-Context-Editor for react using react-intl",
   "homepage": "https://phrase.com",
   "scripts": {


### PR DESCRIPTION
Fixed issues when importing from "react-intl-phraseapp/functions" etc